### PR TITLE
Improve wording for build failure

### DIFF
--- a/every_python/main.py
+++ b/every_python/main.py
@@ -211,7 +211,9 @@ def _build_and_install_unix(
     if not make_result.success:
         if not verbose:
             progress.stop()
-        output.error(f"Build failed: {make_result.stderr if not verbose else ''}")
+            output.error(f"Build failed: {make_result.stderr}")
+        else:
+            output.error("Build failed!")
         raise typer.Exit(1)
 
     # Install


### PR DESCRIPTION
I know this is a minor thing, but I got confused here for a bit why the output was empty but it's because the verbose flag already causes the output to be printed so nothing is captured and the reason is already printend above the statement.