### PR TITLE
Fix python3.0.x binary not found

### DIFF
--- a/every_python/utils.py
+++ b/every_python/utils.py
@@ -192,7 +192,11 @@ def python_binary_location(builds_dir: Path, build_info: "BuildInfo") -> Path:
             return debug_binary
         return builds_dir / build_info.directory_name / "python.exe"
     else:
-        return builds_dir / build_info.directory_name / "bin" / "python3"
+        binary = builds_dir / build_info.directory_name / "bin" / "python3"
+        fallback_binary = builds_dir / build_info.directory_name / "bin" / "python3.0"
+        if not binary.exists() and fallback_binary.exists():
+            return fallback_binary
+        return binary
 
 
 @dataclass


### PR DESCRIPTION
### Explanation
Python3 before the 3.1 release creates a binary name `python3.0` instead of the more common`python3` which every other version uses. I know with 3.0.x being EOL for more than 16 years this probably won't be a common occurrence. But I'm currently working on a archiving project that requires some truly ~~old~~ _historic_  versions and this tool really helped building those CPython versions from source (thanks for that 🎉).

Here is a screenshot of the output from a 3.0.1 build and the binaries produced (please ignore the empty block in the middle I did the `cd` calls with a lot of intermittent steps and so removed it for readability):

<img width="914" height="387" alt="Screenshot 2025-12-29 at 15 16 07" src="https://github.com/user-attachments/assets/5438ffc9-92ab-4aec-9713-1c92a8568885" />

### Considerations
1) I don't have access to a Windows PC right now so I only implemented that fix for Unix platforms (but I don't think it will apply for Windows since the naming seems to be completely different).
2) Should I add some tests for this behavior?

### How I build it
I'm certain you already have well working developing setup but I fell into some pitfalls (like installing python2), so here is the docker file I used for completeness. It fails without before this PR and works with the changes.

<details><summary>Docker setup</summary>

```dockerfile
FROM ubuntu:22.04

ENV DEBIAN_FRONTEND=noninteractive

# Install build dependencies and curl for uv
RUN apt-get update && apt-get install -y build-essential gdb lcov pkg-config \
    libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev \
    libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev \
    lzma lzma-dev tk-dev uuid-dev zlib1g-dev libzstd-dev \
    inetutils-inetd curl git python2.7

# Create a link to call python2 with `python` which is the name the build script for early Python3 versions require it.
RUN ln -s /usr/bin/python2.7 /usr/bin/python

# Install uv
RUN curl -LsSf https://astral.sh/uv/install.sh | sh
ENV PATH="/root/.local/bin:$PATH"

COPY . . 
RUN uv run every-python install v3.0.1
RUN uv run -- every-python run v3.0.1 -- python --version

CMD ["/bin/bash"]
```

On my arm based macOS host machine I also had to build it with the x86 compatibility mode: `docker build --platform linux/amd64 -t every-python .`

</details>