### PR TITLE
➕ Add typing-extensions to project dependencies and update URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.11"
 dependencies = [
     "typer>=0.20.0",
     "rich>=13.0.0",
+    "typing-extensions>=4.1.0",
 ]
 keywords = ["cpython", "python", "build", "testing", "bisect"]
 classifiers = [
@@ -29,7 +30,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/savannahostrowski/every-python"
 Repository = "https://github.com/savannahostrowski/every-python"
-Issues = "https://github.com/savannahostrowski/gruyere/issues"
+Issues = "https://github.com/savannahostrowski/every-python/issues"
 
 [project.scripts]
 every-python = "every_python.main:app"

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,7 @@ source = { editable = "." }
 dependencies = [
     { name = "rich" },
     { name = "typer" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -43,6 +44,7 @@ dev = [
 requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "typer", specifier = ">=0.20.0" },
+    { name = "typing-extensions", specifier = ">=4.1.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Some minor fixes:

1. Added `typing-extensions` to project dependencies

    I tried to install `every-python` with
    
    ```shell
    uv tool install every-python
    ```
    as in the README, and it failed since `typing-extensions` wasn't installed.

2. Fixed possible typo in `project.urls`

    https://github.com/savannahostrowski/every-python/pull/2#discussion_r3050820962
