### PR TITLE
🔖 Bump for 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-21
+
 * ⚡️ Add reference cloning support. PR [#58](https://github.com/savannahostrowski/every-python/pull/58) by [@savannahostrowski](https://github.com/savannahostrowski).
 * ✨ Add support for custom CPython repositories. PR [#57](https://github.com/savannahostrowski/every-python/pull/57) by [@savannahostrowski](https://github.com/savannahostrowski).
 * 📝 Add automated changelog updates. PR [#56](https://github.com/savannahostrowski/every-python/pull/56) by [@savannahostrowski](https://github.com/savannahostrowski).
+
 ### Added
 
 - Add `--reference-repo` and `EVERY_PYTHON_REFERENCE_REPO` to accelerate
@@ -58,7 +61,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Locate older `python3.0` binaries correctly.
 
-[Unreleased]: https://github.com/savannahostrowski/every-python/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/savannahostrowski/every-python/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/savannahostrowski/every-python/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/savannahostrowski/every-python/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/savannahostrowski/every-python/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/savannahostrowski/every-python/compare/v0.4.1...v0.5.0

--- a/README.md
+++ b/README.md
@@ -281,14 +281,16 @@ sys.exit(0)  # Feature doesn't exist - mark as "good"
 
 ```
 ~/.every-python/
-├── cpython/          # Blobless clone of CPython repository
-└── builds/           # Cached builds
-    ├── abc123d/              # Build for commit abc123d
-    ├── abc123d-jit/          # JIT build
-    ├── abc123d-pgo/          # PGO + LTO build
-    ├── abc123d-nogil/        # Free-threaded build
+├── cpython/                    # Managed clone of upstream python/cpython
+├── repos/                      # Managed clones of custom repositories
+│   └── cpython-<hash>/         # One directory per custom repository
+└── builds/                     # Cached builds with repository metadata
+    ├── abc123d/                # Build for commit abc123d
+    ├── abc123d-jit/            # JIT build
+    ├── abc123d-pgo/            # PGO + LTO build
+    ├── abc123d-nogil/          # Free-threaded build
     ├── abc123d-jit-pgo-nogil/  # All flags combined
-    └── def456e/              # Build for commit def456e
+    └── def456e/                # Build for commit def456e
 ```
 
 ## License

--- a/every_python/__init__.py
+++ b/every_python/__init__.py
@@ -1,3 +1,3 @@
 """every-python - A utility for building and running any commit of CPython."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"


### PR DESCRIPTION
## Summary

- bump every-python to 0.7.0
- move the current Unreleased notes into the 0.7.0 release section
- advance changelog comparison links

## Validation

- uv run ruff check .
- uv run ruff format --check .
- uv run ty check
- uv run pytest -q
- uv build